### PR TITLE
Refactor run function to use Enum.each/2

### DIFF
--- a/lib/assertions.ex
+++ b/lib/assertions.ex
@@ -2,7 +2,7 @@ defmodule DoubleBypass.Assertions do
   use ExUnit.CaseTemplate
 
   def run(conn, params) do
-    Enum.map(params, &assert_on(conn, &1))
+    Enum.each(params, &assert_on(conn, &1))
     send_resp(conn, params)
   end
 


### PR DESCRIPTION
Enum.map/2 returns a list which was not being used.
Enum.each/2 would be more appropriate in this case.