### PR TITLE
Add Response Headers to Double Bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use Double Bypass in a test case, tag the test with the bypass tag (defined i
 
 The tag values are the assertions to be made for that test. Double Bypass supports assertions on `headers`, `path`, `query`, `method` and `body` for the request made to the local Bypass server. The presence of any of these values will trigger Double Bypass to assert on the specified value compared to that of the conn object received by the Bypass server.
 
-`response` and `status_code` can be defined as well.  The presence of these values set the response coming from the Bypass server. By default Double Bypass will return status: 200, response: "".
+`response`, `status_code` and `resp_headers` can be defined as well.  The presence of these values set the response coming from the Bypass server. By default Double Bypass will return status: 200, response: "".
 
 ```elixir
 @tag service_bypass: %{
@@ -57,7 +57,8 @@ The tag values are the assertions to be made for that test. Double Bypass suppor
     method: "POST",
     body: %{request: "body"},
     response: %{response: "body"}
-    status_code: 201
+    status_code: 201,
+    resp_headers: [{"content-type", "application/json"}]
   }
   test "POST /path", %{conn: conn} do
     resp = post(conn, "/path", %{request: "body"})
@@ -76,7 +77,8 @@ Double Bypass supports setting up multiple Bypass servers for a single test.  Si
     method: "POST",
     body: %{request: "body"},
     response: %{response: "body"}
-    status_code: 201
+    status_code: 201,
+    resp_headers: [{"content-type", "application/json"}]
   }, service_two_bypass: %{
     path: "/path/two",
     method: "GET",
@@ -100,7 +102,8 @@ Double Bypass returns the Bypass object, so it can be used when performing more 
     method: "POST",
     body: %{request: "body"},
     response: %{response: "body"}
-    status_code: 201
+    status_code: 201,
+    resp_headers: [{"content-type", "application/json"}]
   }, service_two_bypass: %{
     path: "/path/two",
     method: "GET",

--- a/lib/assertions.ex
+++ b/lib/assertions.ex
@@ -9,36 +9,61 @@ defmodule DoubleBypass.Assertions do
     send_resp(conn, params)
   end
 
-  defp assert_on(conn, {:path, path}), do: assert conn.request_path == path
-  defp assert_on(conn, {:query, query}), do: assert conn.query_string == query
-  defp assert_on(conn, {:method, method}), do: assert conn.method == method
-  defp assert_on(conn, {:headers, headers}) do
+  defp assert_on(conn, {:path, path}), do: assert(conn.request_path == path)
+  defp assert_on(conn, {:query, query}), do: assert(conn.query_string == query)
+  defp assert_on(conn, {:method, method}), do: assert(conn.method == method)
+  defp assert_on(conn, {:headers, headers}), do: assert_on(conn, {:req_headers, headers})
+
+  defp assert_on(conn, {:req_headers, req_headers}) do
     conn_headers = conn.req_headers |> Enum.into(%{})
-    Enum.map(headers, fn({k, v}) ->
+
+    Enum.map(req_headers, fn {k, v} ->
       assert conn_headers[k] == v
     end)
   end
+
+  defp assert_on(conn, {:resp_headers, resp_headers}) do
+    conn_headers = conn.resp_headers |> Enum.into(%{})
+
+    Enum.map(resp_headers, fn {k, v} ->
+      assert conn_headers[k] == v
+    end)
+  end
+
   defp assert_on(conn, {:body, body}) when is_bitstring(body) do
     assert conn
-          |> Plug.Conn.read_body
-          |> elem(1) == body
+           |> Plug.Conn.read_body()
+           |> elem(1) == body
   end
+
   defp assert_on(conn, {:body, body}) do
     assert conn
-          |> Plug.Conn.read_body
-          |> elem(1)
-          |> Poison.decode! == body
+           |> Plug.Conn.read_body()
+           |> elem(1)
+           |> Poison.decode!() == body
   end
+
   defp assert_on(_conn, _), do: :noop
 
   defp send_resp(conn, params) do
     case params do
-       %{response: response, status_code: status_code} when is_bitstring(response) -> Plug.Conn.resp(conn, status_code, response)
-       %{response: response, status_code: status_code} -> Plug.Conn.resp(conn, status_code, Poison.encode!(response))
-       %{status_code: status_code} -> Plug.Conn.resp(conn, status_code, "")
-       %{response: response} when is_bitstring(response) -> Plug.Conn.resp(conn, 200, response)
-       %{response: response} -> Plug.Conn.resp(conn, 200, Poison.encode!(response))
-       _ -> Plug.Conn.resp(conn, 200, "")
+      %{response: response, status_code: status_code} when is_bitstring(response) ->
+        Plug.Conn.resp(conn, status_code, response)
+
+      %{response: response, status_code: status_code} ->
+        Plug.Conn.resp(conn, status_code, Poison.encode!(response))
+
+      %{status_code: status_code} ->
+        Plug.Conn.resp(conn, status_code, "")
+
+      %{response: response} when is_bitstring(response) ->
+        Plug.Conn.resp(conn, 200, response)
+
+      %{response: response} ->
+        Plug.Conn.resp(conn, 200, Poison.encode!(response))
+
+      _ ->
+        Plug.Conn.resp(conn, 200, "")
     end
   end
 end

--- a/test/assertions_test.exs
+++ b/test/assertions_test.exs
@@ -10,6 +10,7 @@ defmodule DoubleBypass.AssertionsTest do
   @json_resp_body %{"body" => "body"}
   @string_resp_body "body"
   @status_code 204
+  @resp_headers [{"location", "http://localhost"}]
 
   setup_all do
     body = @json_resp_body |> Poison.encode!
@@ -68,6 +69,12 @@ defmodule DoubleBypass.AssertionsTest do
   test "test status code", %{conn: conn} do
     resp = DoubleBypass.Assertions.run(conn, %{status_code: @status_code})
     assert resp.status == @status_code
+  end
+
+  test "test response headers code", %{conn: conn} do
+    [header] = @resp_headers
+    resp = DoubleBypass.Assertions.run(conn, %{resp_headers: @resp_headers})
+    assert Enum.member?(resp.resp_headers, header)
   end
 
   test "test status code and json response", %{conn: conn} do


### PR DESCRIPTION
## About this PR

This PR is intended to add response headers (`resp_headers`) as a tag value on DoubleBypass.

## Why?

If we need that the Bypass server sends response headers, it's not possible by using the current version of Double Bypass.

## What was done

* Added `resp_headers` as a tag key
* Added a new function, `req_headers`, that is used by the legacy `headers` check
* Updated `README` with the new info